### PR TITLE
Add simple stan store clone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# Link-Store
+# Stan Store Clone
+
+This is a minimal clone of a "Stan Store"-style link store. It provides a simple web page to list products and a JSON API to add new products.
+
+## Usage
+
+1. Run the server:
+
+```bash
+node server.js
+```
+
+2. Open your browser at `http://localhost:3000` to see the product list.
+
+3. Add a new product with a POST request to `/api/products` containing JSON with `name`, `description`, `price`, and `link` fields.
+
+Products are stored in `data.json`.

--- a/data.json
+++ b/data.json
@@ -1,0 +1,8 @@
+[
+  {
+    "name": "Sample Product",
+    "description": "This is a demo product",
+    "price": 9.99,
+    "link": "https://example.com/product"
+  }
+]

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Stan Store Clone</title>
+    <style>
+        body { font-family: Arial, sans-serif; padding: 20px; }
+        .product { margin-bottom: 10px; }
+        .product-title { font-weight: bold; }
+    </style>
+</head>
+<body>
+    <h1>Stan Store Clone</h1>
+    <div id="product-list"></div>
+    <script>
+        async function loadProducts() {
+            const res = await fetch('/api/products');
+            const products = await res.json();
+            const list = document.getElementById('product-list');
+            list.innerHTML = '';
+            products.forEach(p => {
+                const div = document.createElement('div');
+                div.className = 'product';
+                div.innerHTML = `<div class="product-title">${p.name}</div>
+                                 <div>${p.description}</div>
+                                 <div><a href="${p.link}" target="_blank">Buy for $${p.price}</a></div>`;
+                list.appendChild(div);
+            });
+        }
+        loadProducts();
+    </script>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -1,0 +1,68 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const PORT = process.env.PORT || 3000;
+const dataFile = path.join(__dirname, 'data.json');
+const publicDir = path.join(__dirname, 'public');
+
+function readProducts() {
+    try {
+        const data = fs.readFileSync(dataFile, 'utf8');
+        return JSON.parse(data);
+    } catch (err) {
+        return [];
+    }
+}
+
+function writeProducts(products) {
+    fs.writeFileSync(dataFile, JSON.stringify(products, null, 2));
+}
+
+const server = http.createServer((req, res) => {
+    if (req.url.startsWith('/api/products')) {
+        if (req.method === 'GET') {
+            const products = readProducts();
+            res.setHeader('Content-Type', 'application/json');
+            res.end(JSON.stringify(products));
+        } else if (req.method === 'POST') {
+            let body = '';
+            req.on('data', chunk => body += chunk);
+            req.on('end', () => {
+                try {
+                    const product = JSON.parse(body);
+                    const products = readProducts();
+                    products.push(product);
+                    writeProducts(products);
+                    res.statusCode = 201;
+                    res.end('created');
+                } catch (err) {
+                    res.statusCode = 400;
+                    res.end('invalid');
+                }
+            });
+        } else {
+            res.statusCode = 405;
+            res.end();
+        }
+    } else {
+        // serve static files
+        let filePath = req.url === '/' ? '/index.html' : req.url;
+        const absPath = path.join(publicDir, filePath);
+        fs.readFile(absPath, (err, data) => {
+            if (err) {
+                res.statusCode = 404;
+                res.end('Not found');
+            } else {
+                if (filePath.endsWith('.html')) res.setHeader('Content-Type', 'text/html');
+                if (filePath.endsWith('.js')) res.setHeader('Content-Type', 'application/javascript');
+                if (filePath.endsWith('.css')) res.setHeader('Content-Type', 'text/css');
+                res.end(data);
+            }
+        });
+    }
+});
+
+server.listen(PORT, () => {
+    console.log(`Server listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- create minimal Stan Store clone in Node.js
- provide server code and simple HTML page
- add sample data and instructions in README

## Testing
- `node -v`
- `npm -v`
- `npm install express` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68492e2cd0948322838cf6da0a360908